### PR TITLE
Remove need for IsFull, see BitBoard c'tor

### DIFF
--- a/TicTacToe.Core/BitBoard.cs
+++ b/TicTacToe.Core/BitBoard.cs
@@ -7,14 +7,21 @@ namespace TicTacToe.Core
     {
         private uint _value;
 
-        public BitBoard(uint value) 
+        public BitBoard(uint value)
         {
-            _value = value;
+            SetValue(value);
         }
         public BitBoard() : this(0)
         {
         }
 
+        private void SetValue(uint value)
+        {
+            // 11111111111111111111111 000 000 000 = 4294966784
+            // this is the same as zero for our purposes, where
+            // we are using the first few bits.
+            _value = value == 4294966784 ? (uint) 0 : value;
+        }
         public uint GetValue()
         {
             // see: { get; } or  {get; set;} for shorthand version of this.
@@ -33,12 +40,8 @@ namespace TicTacToe.Core
 
         public void PopBit(Square square)
         {
-            _value &= ~uint.RotateLeft(1, Convert.ToUInt16(square));
-            // Pop bit can create a number:
-            //   11111111111111111111111 000 000 000 = 4294966784
-            // this is the same as zero for our purposes, where
-            // we are using the first few bits.
-            if (_value == 4294966784) _value = 0;
+            var popped = _value  & ~uint.RotateLeft(1, Convert.ToUInt16(square));
+            SetValue(popped);
         }
 
        public Square IndexLSB()
@@ -48,7 +51,7 @@ namespace TicTacToe.Core
         }
 
 
-        public bool isEmpty()
+        public bool IsEmpty()
         {
             return _value == 0;
         }

--- a/TicTacToe.Core/Board.cs
+++ b/TicTacToe.Core/Board.cs
@@ -80,14 +80,10 @@ namespace TicTacToe.Core
 
         public List<Square> GetMoves()
         {
-            if (IsFull()) return new List<Square>();
-
-            // Strictly, we shouldn't need the above check, but full board, 
-            // can still return moves; need to check two's compliment without
-            // the above clause; this works.
             var moves = new List<Square>();
             var freeSquares = new BitBoard(~(_naughts.GetValue() | _crosses.GetValue()));
-            while (!freeSquares.isEmpty())
+
+            while (!freeSquares.IsEmpty())
             {
                 var square = freeSquares.IndexLSB();
                 moves.Add(square);


### PR DESCRIPTION
I took a look at the code, looks good.
One improvement;

Some bit operations can generate this value:

11111111111111111111111 000 000 000 = 4294966784

Note, the tic tac toe bitboard only uses the first 9 digits.
So, this number is the same as zero.

Providing a 'SetValue' method, you can get rid of the extra 'IsFull' check in the 'GetMoves' method.
It also futures proofs any other changes.
